### PR TITLE
Remove SERVICES env var

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ jobs:
     env:
       LOCALSTACK_HOST: localstack
       LOCALSTACK_PORT: 4566
-      SERVICES: dynamodb,s3
       AWS_ACCESS_KEY_ID: unknown
       AWS_SECRET_ACCESS_KEY: unknown
       AWS_REGION: us-east-1

--- a/test/prevayler_clj_aws/core_test.clj
+++ b/test/prevayler_clj_aws/core_test.clj
@@ -14,8 +14,7 @@
   (memoize
    #(or (some-> (System/getenv "LOCALSTACK_PORT") (Integer/parseInt))
         (-> (tc/create {:image-name "localstack/localstack"
-                        :exposed-ports [4566]
-                        :env-vars {"SERVICES" "dynamodb,s3"}})
+                        :exposed-ports [4566]})
             (tc/start!)
             :mapped-ports
             (get 4566)))))


### PR DESCRIPTION
Newest versions of localstack start services lazily, so adding the env var is a no-op.